### PR TITLE
fix: Roll back Stripe SDK to 4.7

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,7 @@ android {
             isDebuggable = false
             isMinifyEnabled = false
             signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release", "debug")
         }
         release {
             isMinifyEnabled = false
@@ -67,8 +68,8 @@ dependencies {
     implementation("com.google.androidbrowserhelper:androidbrowserhelper:2.6.2")
 
     // Stripe Terminal (Tap to Pay)
-    implementation("com.stripe:stripeterminal-taptopay:5.1.1")
-    implementation("com.stripe:stripeterminal-core:5.1.1")
+    implementation("com.stripe:stripeterminal-taptopay:4.7.6")
+    implementation("com.stripe:stripeterminal-core:4.7.6")
 
     // HTTP + JSON
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/app/src/main/java/com/example/lnbitstaptopay/MainActivity.kt
+++ b/app/src/main/java/com/example/lnbitstaptopay/MainActivity.kt
@@ -20,7 +20,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import com.google.androidbrowserhelper.trusted.TwaLauncher
 
-// Stripe Terminal SDK (5.1.1)
+// Stripe Terminal SDK (4.7.6)
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.external.callable.*
 import com.stripe.stripeterminal.external.models.*
@@ -298,12 +298,11 @@ class MainActivity : ComponentActivity() {
         }
 
         if (!terminalInitialized) {
-            Terminal.init(
+            Terminal.initTerminal(
                 applicationContext,
                 LogLevel.VERBOSE,
                 tokenProvider(),
-                object : TerminalListener {},
-                null
+                object : TerminalListener {}
             )
             terminalInitialized = true
         }
@@ -567,12 +566,11 @@ class MainActivity : ComponentActivity() {
 
         if (!terminalInitialized) {
             onPhase("Initializing Stripe SDK")
-            Terminal.init(
+            Terminal.initTerminal(
                 applicationContext,
                 LogLevel.VERBOSE,
                 tokenProvider(),
-                object : TerminalListener {},
-                null
+                object : TerminalListener {}
             )
             terminalInitialized = true
         }


### PR DESCRIPTION
As v5+ of the SDK persists hardware key  attestation and is far less supported across devices
